### PR TITLE
Adds repositories property

### DIFF
--- a/src/main/groovy/wooga/gradle/upm/artifactory/internal/MapPropertyWithRightDefault.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/internal/MapPropertyWithRightDefault.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.upm.artifactory.internal
+
+import org.gradle.api.internal.provider.DefaultMapProperty
+import org.gradle.api.internal.provider.DefaultPropertyFactory
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
+
+class MapPropertyWithRightDefault<K, V> extends DefaultMapProperty<K, V> {
+
+    MapProperty<K, V> defaultValue;
+
+    MapPropertyWithRightDefault(ObjectFactory objects, Class<K> keyType, Class<V> valueType) {
+        super(((DefaultPropertyFactory)objects.propertyFactory).propertyHost, keyType, valueType)
+        defaultValue = objects.mapProperty(keyType, valueType)
+    }
+
+    @Override
+    void set(Provider<? extends Map<? extends K, ? extends V>> provider) {
+        super.set(provider.orElse(defaultValue))
+    }
+
+    @Override
+    MapProperty<K, V> value(Provider<? extends Map<? extends K, ? extends V>> provider) {
+        return super.value(provider.orElse(defaultValue))
+    }
+
+    @Override
+    MapProperty<K, V> convention(Map<? extends K, ? extends V> valueProvider) {
+        defaultValue.set(valueProvider as Map)
+        return this
+    }
+
+    @Override
+    MapProperty<K, V> convention(Provider<? extends Map<? extends K, ? extends V>> valueProvider) {
+        defaultValue.set(valueProvider as Provider)
+        return this
+    }
+}

--- a/src/main/groovy/wooga/gradle/upm/artifactory/traits/UPMPublishSpec.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/traits/UPMPublishSpec.groovy
@@ -1,15 +1,35 @@
 package wooga.gradle.upm.artifactory.traits
 
 import com.wooga.gradle.BaseSpec
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.options.Option
+import wooga.gradle.upm.artifactory.internal.MapPropertyWithRightDefault
+import wooga.gradle.upm.artifactory.internal.repository.UPMArtifactRepository
 
 trait UPMPublishSpec implements BaseSpec {
 
+    @Option(option = "repositories", description = """
+    Repositories [name: UPMArtifactRepository] that be used as publishing target by atlas-upm-artifactory
+    """)
+    private final MapProperty<String, UPMArtifactRepository> repositories = new MapPropertyWithRightDefault<>(objects, String, UPMArtifactRepository)
+
+    MapProperty<String, UPMArtifactRepository> getRepositories() {
+        return repositories
+    }
+
+    void setRepositories(Provider<Map<String, UPMArtifactRepository>> repositories) {
+        this.repositories.set(repositories)
+    }
+
+    void setRepositories(Map<String, UPMArtifactRepository> repositories) {
+        this.repositories.set(repositories)
+    }
+
     @Option(option = "repository", description = """
-    The repository where the UPM package will be published. Must match of the UPM repositories declared previously on the publishing extension.
+    The repository where the UPM package will be published. Must match of the UPM repositories declared on repositories or in the publishing extension.
     """)
     private final Property<String> repository = objects.property(String)
 


### PR DESCRIPTION
## Description

Adds new property `repositories` that allows UPM repositories to be set in the extension directly. This property is fed with the values set in the Publishing Plugin, so no current behaviour has changed. 

This change is needed for us to be able to set default repositories in `atlas-wdk-unity-release`. 

## Changes
* ![ADD] `repositories` extension property.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"