### PR TITLE
Adds customizePackage block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,9 @@ cveHandler {
 
 dependencies {
     implementation "net.wooga.gradle:dotnet-sonarqube:[1,2["
-    implementation "net.wooga.gradle:unity:[4,5["
+    implementation "net.wooga.gradle:unity:[4.1.0,5["
     implementation "commons-io:commons-io:2.11.0"
+    implementation "org.apache.commons:commons-compress:1.22"
     implementation 'com.wooga.gradle:gradle-commons:[1.6.1,2['
     implementation 'org.ajoberstar.grgit:grgit-gradle:[4.1.1,5['
     implementation 'org.ajoberstar.grgit:grgit-core:[4.1.1,5['

--- a/src/main/groovy/wooga/gradle/upm/artifactory/UPMProjectDeclaration.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/UPMProjectDeclaration.groovy
@@ -4,9 +4,12 @@ import org.gradle.api.Named
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
+import wooga.gradle.unity.tasks.GenerateUpmPackage
 import wooga.gradle.upm.artifactory.internal.Extensions
 import wooga.gradle.upm.artifactory.internal.UPMProjectConfigurator
 import wooga.gradle.upm.artifactory.traits.UPMPackSpec
+
+import java.util.function.Consumer
 
 class UPMProjectDeclaration implements UPMPackSpec, Named {
 

--- a/src/main/groovy/wooga/gradle/upm/artifactory/internal/UPMProjectConfigurator.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/internal/UPMProjectConfigurator.groovy
@@ -66,6 +66,11 @@ class UPMProjectConfigurator {
             //we need to set this explicitly for projects on subplugins.
             it.destinationDirectory.convention(basePluginConvention.flatMap { it.distsDirectory })
             it.dependsOn(generateMetafiles)
+            upmProject.packageCustomizers.get().each { patcher ->
+                Closure cls = patcher.&accept
+                cls.setDelegate(it)
+                cls.call(it)
+            }
         }
         return upmPack
     }

--- a/src/main/groovy/wooga/gradle/upm/artifactory/traits/UPMPackSpec.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/traits/UPMPackSpec.groovy
@@ -3,10 +3,15 @@ package wooga.gradle.upm.artifactory.traits
 import com.wooga.gradle.BaseSpec
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.options.Option
+import wooga.gradle.unity.traits.GenerateUpmPackageSpec
+
+import java.util.function.Consumer
 
 trait UPMPackSpec extends BaseSpec {
 
@@ -64,4 +69,23 @@ trait UPMPackSpec extends BaseSpec {
         generateMetaFiles.set(value)
     }
 
+    private final ListProperty<Consumer<GenerateUpmPackageSpec>> packageCustomizers = objects.listProperty(Consumer<GenerateUpmPackageSpec>)
+
+    @Input
+    @Optional
+    ListProperty<Consumer<GenerateUpmPackageSpec>> getPackageCustomizers() {
+        return packageCustomizers
+    }
+
+    void setPackageCustomizers(Provider<? extends Iterable<Consumer<GenerateUpmPackageSpec>>> patchers) {
+        packageCustomizers.set(patchers)
+    }
+
+    void setPackageCustomizers(Iterable<Consumer<GenerateUpmPackageSpec>> patchers) {
+        packageCustomizers.set(patchers)
+    }
+
+    void customizePackage(Consumer<GenerateUpmPackageSpec> patcher) {
+        this.packageCustomizers.add(patcher)
+    }
 }


### PR DESCRIPTION
## Description
Adds `customizePackage` function to the `UPMProjectDeclaration` class, allowing users to apply patches in the package.json files before they get bundled.

## Changes
* ![ADD] `customizePackage` configuration block


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
