### PR TITLE
Extracts reusable code into resolvePackageDirectory [ATLAS-1464]

### DIFF
--- a/src/main/groovy/wooga/gradle/upm/artifactory/UPMArtifactoryConventions.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/UPMArtifactoryConventions.groovy
@@ -51,10 +51,4 @@ class UPMArtifactoryConventions {
                            "upm.generate.metafiles"] },
             { false }
     )
-
-    static final Provider<Directory> resolvePackageDirectory(Project project, String name) {
-        packageDirectory.resolve(name)
-                .getDirectoryValueProvider(project, null, project.providers.provider{project.layout.projectDirectory})
-    }
-
 }

--- a/src/main/groovy/wooga/gradle/upm/artifactory/UPMArtifactoryConventions.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/UPMArtifactoryConventions.groovy
@@ -2,9 +2,6 @@ package wooga.gradle.upm.artifactory
 
 import com.wooga.gradle.PropertyLookup
 import com.wooga.gradle.PropertyUtils
-import org.gradle.api.Project
-import org.gradle.api.file.Directory
-import org.gradle.api.provider.Provider
 import wooga.gradle.upm.artifactory.internal.DynamicPropertyLookup
 
 class UPMArtifactoryConventions {

--- a/src/main/groovy/wooga/gradle/upm/artifactory/UPMArtifactoryConventions.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/UPMArtifactoryConventions.groovy
@@ -2,6 +2,9 @@ package wooga.gradle.upm.artifactory
 
 import com.wooga.gradle.PropertyLookup
 import com.wooga.gradle.PropertyUtils
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import wooga.gradle.upm.artifactory.internal.DynamicPropertyLookup
 
 class UPMArtifactoryConventions {
@@ -48,4 +51,10 @@ class UPMArtifactoryConventions {
                            "upm.generate.metafiles"] },
             { false }
     )
+
+    static final Provider<Directory> resolvePackageDirectory(Project project, String name) {
+        packageDirectory.resolve(name)
+                .getDirectoryValueProvider(project, null, project.providers.provider{project.layout.projectDirectory})
+    }
+
 }

--- a/src/main/groovy/wooga/gradle/upm/artifactory/UPMProjectDeclaration.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/UPMProjectDeclaration.groovy
@@ -28,7 +28,10 @@ class UPMProjectDeclaration implements UPMPackSpec, Named {
 
     static final Provider<Directory> resolvePackageDirectory(Project project, String name) {
         UPMArtifactoryConventions.packageDirectory.resolve(name)
-                .getDirectoryValueProvider(project, null, project.providers.provider{project.layout.projectDirectory})
+                .getDirectoryValueProvider(project, null,
+                        project.providers.provider({
+                            project.layout.projectDirectory
+                        }))
     }
 
     UPMProjectDeclaration() {}

--- a/src/main/groovy/wooga/gradle/upm/artifactory/UPMProjectDeclaration.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/UPMProjectDeclaration.groovy
@@ -4,13 +4,9 @@ import org.gradle.api.Named
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
-import wooga.gradle.unity.UnityPluginExtension
-import wooga.gradle.unity.tasks.GenerateUpmPackage
 import wooga.gradle.upm.artifactory.internal.Extensions
 import wooga.gradle.upm.artifactory.internal.UPMProjectConfigurator
 import wooga.gradle.upm.artifactory.traits.UPMPackSpec
-
-import java.util.function.Consumer
 
 class UPMProjectDeclaration implements UPMPackSpec, Named {
 
@@ -24,10 +20,15 @@ class UPMProjectDeclaration implements UPMPackSpec, Named {
         Extensions.setPropertiesOwner(UPMProjectDeclaration, extension, name)
         extension.with {
             version.convention(UPMArtifactoryConventions.version.resolve(name).getStringValueProvider(project).orElse(project.provider { project.version.toString() }))
-            packageDirectory.convention(UPMArtifactoryConventions.resolvePackageDirectory(project, name))
+            packageDirectory.convention(resolvePackageDirectory(project, name))
             generateMetaFiles.convention(UPMArtifactoryConventions.generateMetaFiles.resolve(name).getBooleanValueProvider(project))
         }
         return extension
+    }
+
+    static final Provider<Directory> resolvePackageDirectory(Project project, String name) {
+        UPMArtifactoryConventions.packageDirectory.resolve(name)
+                .getDirectoryValueProvider(project, null, project.providers.provider{project.layout.projectDirectory})
     }
 
     UPMProjectDeclaration() {}

--- a/src/main/groovy/wooga/gradle/upm/artifactory/UPMProjectDeclaration.groovy
+++ b/src/main/groovy/wooga/gradle/upm/artifactory/UPMProjectDeclaration.groovy
@@ -4,6 +4,7 @@ import org.gradle.api.Named
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
+import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.tasks.GenerateUpmPackage
 import wooga.gradle.upm.artifactory.internal.Extensions
 import wooga.gradle.upm.artifactory.internal.UPMProjectConfigurator
@@ -23,9 +24,7 @@ class UPMProjectDeclaration implements UPMPackSpec, Named {
         Extensions.setPropertiesOwner(UPMProjectDeclaration, extension, name)
         extension.with {
             version.convention(UPMArtifactoryConventions.version.resolve(name).getStringValueProvider(project).orElse(project.provider { project.version.toString() }))
-            Provider<Directory> defaultDir = UPMArtifactoryConventions.packageDirectory.resolve(name)
-                    .getDirectoryValueProvider(project, null, providers.provider{project.layout.projectDirectory})
-            packageDirectory.convention(defaultDir)
+            packageDirectory.convention(UPMArtifactoryConventions.resolvePackageDirectory(project, name))
             generateMetaFiles.convention(UPMArtifactoryConventions.generateMetaFiles.resolve(name).getBooleanValueProvider(project))
         }
         return extension

--- a/src/test/groovy/wooga/gradle/upm/artifactory/UPMProjectDeclarationSpec.groovy
+++ b/src/test/groovy/wooga/gradle/upm/artifactory/UPMProjectDeclarationSpec.groovy
@@ -1,0 +1,20 @@
+package wooga.gradle.upm.artifactory
+import nebula.test.ProjectSpec
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+
+class UPMProjectDeclarationSpec extends ProjectSpec {
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    def "Resolves Package directory in Project root folder"() {
+        given:
+        def fooRoot = "fooRoot"
+        def fooProject = "foo"
+        environmentVariables.set("UPM_${fooProject.toUpperCase()}_PACKAGE_DIR", fooRoot);
+        when:
+        def packageDir = UPMProjectDeclaration.resolvePackageDirectory(project, fooProject)
+        then:
+        packageDir.get().asFile.absolutePath == project.layout.projectDirectory.dir(fooRoot).asFile.absolutePath
+    }
+}


### PR DESCRIPTION
## Description

Just a small simple architectural non-semantic change. Extracts existing code into new convenience function in UPMProjectDeclaration to resolve the Package Directory in a project.

## Changes
* ![ADD] adds convenience function in UPMProjectDeclaration to resolve the Package Directory


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
